### PR TITLE
support end of semicolon

### DIFF
--- a/app/components/DatabaseTree/DatabaseTree.js
+++ b/app/components/DatabaseTree/DatabaseTree.js
@@ -137,7 +137,7 @@ export default class DatabaseTree extends Component {
       this.setState({
         data: {
           icon: 'appstore',
-          name: databaseAlias ? databaseAlias : 'server alias',
+          name: databaseAlias || 'server alias',
           database_host: localStorage.getItem(localStorageVariables.database.host),
           toggled: true,
           error: false,

--- a/app/components/QueryLaunch.js
+++ b/app/components/QueryLaunch.js
@@ -180,11 +180,10 @@ export default class QueryLaunch extends Component<Props> {
   };
 
   getQuery = () => {
-    if (this.aceEditor.current.editor.getSelectedText().length > 0) {
-      return this.aceEditor.current.editor.getSelectedText();
-    }
-
-    return this.state.value;
+    let queryText = this.aceEditor.current.editor.getSelectedText() || this.state.value;
+    // remove the ending spaces and semicolons
+    queryText = queryText.replace(/;*\s*$/, '');
+    return queryText;
   };
 
   onQuery = async (e, dropConfirmation = false) => {


### PR DESCRIPTION
In ClickHouse, it supports SQL with excessive semicolons  like this `select number,count() from numbers(10) group by number;;;    `

So it would be better to have  this feature